### PR TITLE
getNearestDate did verify months with days

### DIFF
--- a/src/node_modules/@data/Constants/utils.js
+++ b/src/node_modules/@data/Constants/utils.js
@@ -124,12 +124,12 @@ export function getNearestDateWithinEmployment(date: Moment, user: ApiUserType):
     let endDate = user.usr_employment_stop;
     // give one month more time before and after
     if (startDate) {
-        startDate = moment(startDate);
+        startDate = moment(startDate).startOf('month');
         if (date.isBefore(startDate)) return startDate;
     }
 
     if (endDate) {
-        endDate = moment(endDate);
+        endDate = moment(endDate).startOf('month');
         if (date.isAfter(endDate)) return endDate;
     } else {
         // check if we want more than a year into the future and stop it


### PR DESCRIPTION
it did not handle correct if users started within a month, therefore date was always before the employment_start_date and therefore it ran into a never ending loop